### PR TITLE
Front

### DIFF
--- a/consumidor_twitches/webserver/requirements.txt
+++ b/consumidor_twitches/webserver/requirements.txt
@@ -2,3 +2,7 @@ Django==2.2.6
 pytz==2019.3
 sqlparse==0.3.0
 mysql-connector-python==8.0.17
+chaostoolkit==1.3.0
+chaostoolkit-kubernetes==0.21.0
+chaostoolkit-lib==1.7.1
+chaostoolkit-reporting==0.13.0

--- a/interface/webserver/requirements.txt
+++ b/interface/webserver/requirements.txt
@@ -2,3 +2,5 @@ Django==2.2.6
 pytz==2019.3
 sqlparse==0.3.0
 mysql-connector-python==8.0.17
+requests==2.22.0
+redis==3.3.11

--- a/interface/webserver/static/assets/css/custom_style.css
+++ b/interface/webserver/static/assets/css/custom_style.css
@@ -1,0 +1,7 @@
+.fundo-roxo{
+    background: #846d7f !important
+}
+
+.fundo-roxo-claro {
+    background: #e1c5e6;
+}

--- a/interface/webserver/static/assets/js/webserver/servico1.js
+++ b/interface/webserver/static/assets/js/webserver/servico1.js
@@ -6,7 +6,9 @@ function post_servico_saudavel() {
         success: function (response) {
             resultado = response;
             $("#ultima_requisicao_saudavel").text(resultado.ultima_requisicao_saudavel);
-            $("#tempo_medio_request_saudavel").text(resultado.tempo_request_saudavel);
+            $("#tempo_medio_resposta_saudavel").text(resultado.tempo_medio_resposta_saudavel);
+            $("#numero_requisicoes_realizadas_saudavel").text(resultado.numero_requisicoes_realizadas_saudavel);
+            $("#numero_requisicoes_bem_sucedidas_saudavel").text(resultado.numero_requisicoes_bem_sucedidas_saudavel);
         }
     });
 }
@@ -19,7 +21,9 @@ function post_servico_teste() {
         success: function (response) {
             resultado = response;
             $("#ultima_requisicao_chaos").text(resultado.ultima_requisicao_chaos);
-            $("#tempo_medio_request_chaos").text(resultado.tempo_request_chaos);
+            $("#tempo_medio_resposta_chaos").text(resultado.tempo_medio_resposta_chaos);
+            $("#numero_requisicoes_realizadas_chaos").text(resultado.numero_requisicoes_realizadas_chaos);
+            $("#numero_requisicoes_bem_sucedidas_chaos").text(resultado.numero_requisicoes_bem_sucedidas_chaos);
         }
     });
 }

--- a/interface/webserver/static/assets/js/webserver/servico1.js
+++ b/interface/webserver/static/assets/js/webserver/servico1.js
@@ -1,29 +1,43 @@
 function post_servico_saudavel() {
+    $("#informe_saudavel").show()
     $.ajax({
         type: 'GET',
         url: url_servico_saudavel,
         data: {},
         success: function (response) {
+            $("#informe_saudavel").hide();
+            $("#informe_saudavel_ok").show();
+            timeoutID = setTimeout('$("#informe_saudavel_ok").hide()', 1*1000);
             resultado = response;
             $("#ultima_requisicao_saudavel").text(resultado.ultima_requisicao_saudavel);
             $("#tempo_medio_resposta_saudavel").text(resultado.tempo_medio_resposta_saudavel);
             $("#numero_requisicoes_realizadas_saudavel").text(resultado.numero_requisicoes_realizadas_saudavel);
             $("#numero_requisicoes_bem_sucedidas_saudavel").text(resultado.numero_requisicoes_bem_sucedidas_saudavel);
+        },
+        error: function(request, satus, error){
+            $("#informe_saudavel").hide()
         }
     });
 }
 
 function post_servico_teste() {
+    $("#informe_chaos").show()
     $.ajax({
         type: 'GET',
         url: url_servico_teste,
         data: {},
         success: function (response) {
+            $("#informe_chaos").hide();
+            $("#informe_chaos_ok").show();
+            timeoutID = setTimeout('$("#informe_chaos_ok").hide()', 1*1000);
             resultado = response;
             $("#ultima_requisicao_chaos").text(resultado.ultima_requisicao_chaos);
             $("#tempo_medio_resposta_chaos").text(resultado.tempo_medio_resposta_chaos);
             $("#numero_requisicoes_realizadas_chaos").text(resultado.numero_requisicoes_realizadas_chaos);
             $("#numero_requisicoes_bem_sucedidas_chaos").text(resultado.numero_requisicoes_bem_sucedidas_chaos);
+        },
+        error: function(request, satus, error){
+            $("#informe_chaos").hide()
         }
     });
 }

--- a/interface/webserver/static/assets/js/webserver/servico1.js
+++ b/interface/webserver/static/assets/js/webserver/servico1.js
@@ -1,16 +1,24 @@
 function post_servico_saudavel() {
-    var csrftoken = getCookie('csrftoken');
     $.ajax({
-        type: 'POST',
+        type: 'GET',
         url: url_servico_saudavel,
-        data: {
-            csrfmiddlewaretoken: csrftoken
-        },
+        data: {},
         success: function (response) {
             resultado = response;
             $("#ultima_requisicao_saudavel").text(resultado.ultima_requisicao_saudavel);
-            $("#ultima_requisicao_chaos").text(resultado.ultima_requisicao_chaos);
             $("#tempo_request_saudavel").text(resultado.tempo_request_saudavel);
+        }
+    });
+}
+
+function post_servico_teste() {
+    $.ajax({
+        type: 'GET',
+        url: url_servico_teste,
+        data: {},
+        success: function (response) {
+            resultado = response;
+            $("#ultima_requisicao_chaos").text(resultado.ultima_requisicao_chaos);
             $("#tempo_request_chaos").text(resultado.tempo_request_chaos);
         }
     });

--- a/interface/webserver/static/assets/js/webserver/servico1.js
+++ b/interface/webserver/static/assets/js/webserver/servico1.js
@@ -6,7 +6,7 @@ function post_servico_saudavel() {
         success: function (response) {
             resultado = response;
             $("#ultima_requisicao_saudavel").text(resultado.ultima_requisicao_saudavel);
-            $("#tempo_request_saudavel").text(resultado.tempo_request_saudavel);
+            $("#tempo_medio_request_saudavel").text(resultado.tempo_request_saudavel);
         }
     });
 }
@@ -19,7 +19,7 @@ function post_servico_teste() {
         success: function (response) {
             resultado = response;
             $("#ultima_requisicao_chaos").text(resultado.ultima_requisicao_chaos);
-            $("#tempo_request_chaos").text(resultado.tempo_request_chaos);
+            $("#tempo_medio_request_chaos").text(resultado.tempo_request_chaos);
         }
     });
 }

--- a/interface/webserver/webserver/templates/webserver/base_generic.html
+++ b/interface/webserver/webserver/templates/webserver/base_generic.html
@@ -89,7 +89,7 @@
               </a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="{% url 'servico_saudavel' %}">
+              <a class="nav-link" href="{% url 'render_status_servico' %}">
                 <span class="menu-title">Consumidor Twitter</span>
                 <i class="mdi mdi-access-point menu-icon"></i>
               </a>

--- a/interface/webserver/webserver/templates/webserver/base_generic.html
+++ b/interface/webserver/webserver/templates/webserver/base_generic.html
@@ -22,6 +22,7 @@
     <!-- endinject -->
     <!-- Layout styles -->
     <link rel="stylesheet" href="{% static 'assets/css/style.css' %}">
+    <link rel="stylesheet" href="{% static 'assets/css/custom_style.css' %}">
     <!-- End layout styles -->
     <link rel="shortcut icon" href="{% static 'assets/images/favicon.png' %}" />
 
@@ -34,10 +35,10 @@
   <body>
     <div class="container-scroller">
       <!-- partial:{% static 'partials/_navbar.html -->
-      <nav class="navbar default-layout-navbar col-lg-12 col-12 p-0 fixed-top d-flex flex-row">
-        <div class="text-center navbar-brand-wrapper d-flex align-items-center justify-content-center">
-          <a class="navbar-brand brand-logo" href="../../index.html"><img src="{% static 'assets/images/logo.png' %}" alt="logo" /></a>
-          <a class="navbar-brand brand-logo-mini" href="../../index.html"><img src="{% static 'assets/images/logo-mini.png' %}" alt="logo" /></a>
+      <nav class="navbar default-layout-navbar col-lg-12 col-12 p-0 fixed-top d-flex flex-row fundo-roxo">
+        <div class="text-center navbar-brand-wrapper d-flex align-items-center justify-content-center fundo-roxo">
+          <a class="navbar-brand brand-logo" href="../../index.html"><!--img src="{% static 'assets/images/logo.png' %}" alt="logo" /--></a>
+          <a class="navbar-brand brand-logo-mini" href="../../index.html"><!--img src="{% static 'assets/images/logo-mini.png' %}" alt="logo" /--></a>
         </div>
         <div class="navbar-menu-wrapper d-flex align-items-stretch">
           <button class="navbar-toggler navbar-toggler align-self-center" type="button" data-toggle="minimize">
@@ -66,7 +67,7 @@
       <!-- partial -->
       <div class="container-fluid page-body-wrapper">
         <!-- partial:{% static 'partials/_sidebar.html -->
-        <nav class="sidebar sidebar-offcanvas" id="sidebar">
+        <nav class="sidebar sidebar-offcanvas fundo-roxo" id="sidebar">
           <ul class="nav">
             <li class="nav-item nav-profile">
               <a href="#" class="nav-link">
@@ -117,7 +118,7 @@
           </ul>
         </nav>
         <!-- partial -->
-        <div class="main-panel">
+        <div class="main-panel fundo-roxo-claro">
           <div class="content-wrapper p-3 has-inner-drawer">
             <div class="page-header">
               <h3 class="page-title">

--- a/interface/webserver/webserver/templates/webserver/servico1.html
+++ b/interface/webserver/webserver/templates/webserver/servico1.html
@@ -14,6 +14,8 @@
           <!--<img src="{% static 'assets/images/dashboard/circle.svg' %}" class="card-img-absolute" alt="circle-image"/>-->
           <h3 class="font-weight-normal mb-3" style="text-align: center">Aplicação Saudável <i class="mdi mdi-chart-line mdi-24px float-right" onclick="post_servico_saudavel()" style=" cursor: pointer"></i>
           </h3>
+          <h6 class="card-text" id="informe_saudavel" style="text-align: center; display: none" >Requisição Iniciada!</h6>
+          <h6 class="card-text" id="informe_saudavel_ok" style="text-align: center; display: none" >OK!</h6>
           <span></span>
           <h6 class="card-text">Numero de requisicoes realizadas</h6>
           <h2 class="mb-5" id="numero_requisicoes_realizadas_saudavel">{{num_total_requicoes_saudavel}}</h2>
@@ -31,8 +33,10 @@
       <div class="card bg-gradient-danger card-img-holder text-white">
         <div class="card-body">
           <!--<img src="{% static 'assets/images/dashboard/circle.svg' %}" class="card-img-absolute" alt="circle-image" />-->
-          <h3 class="font-weight-normal mb-3" style="text-align: center">Aplicação Controlada <i class="mdi mdi-chart-line mdi-24px float-right" onclick="post_servico_teste()" style="cursor: pointer"></i>
+          <h3 class="font-weight-normal mb-3" style="text-align: center">Aplicação em Chaos <i class="mdi mdi-chart-line mdi-24px float-right" onclick="post_servico_teste()" style="cursor: pointer"></i>
           </h3>
+          <h6 class="card-text" id="informe_chaos" style="text-align: center; display: none" >Requisição Iniciada!</h6>
+          <h6 class="card-text" id="informe_chaos_ok" style="text-align: center; display: none" >OK!</h6>
           <span></span>
           <h6 class="card-text">Numero de requisicoes realizadas</h6>
           <h2 class="mb-5" id="numero_requisicoes_realizadas_chaos">{{num_total_requicoes_chaos}}</h2>

--- a/interface/webserver/webserver/templates/webserver/servico1.html
+++ b/interface/webserver/webserver/templates/webserver/servico1.html
@@ -26,7 +26,7 @@
     <div class="col-md-6 stretch-card grid-margin">
       <div class="card bg-gradient-danger card-img-holder text-white">
         <div class="card-body">
-          <img src="{% static 'assets/images/dashboard/circle.svg' %}" class="card-img-absolute" alt="circle-image"/>
+          <img src="{% static 'assets/images/dashboard/circle.svg' %}" class="card-img-absolute" alt="circle-image" onclick="post_servico_teste()" style="cursor: pointer"/>
           <h3 class="font-weight-normal mb-3" style="text-align: center">Aplicação Controlada <i class="mdi mdi-chart-line mdi-24px float-right"></i>
           </h3>
           <span></span>
@@ -47,6 +47,7 @@
 
   <script>
     var url_servico_saudavel = "{% url 'servico_saudavel' %}";
-    var resultado = ""
+    var url_servico_teste = "{% url 'servico_teste' %}";
+    var resultado = "";
   </script>
 {% endblock additional_script %}

--- a/interface/webserver/webserver/templates/webserver/servico1.html
+++ b/interface/webserver/webserver/templates/webserver/servico1.html
@@ -11,10 +11,14 @@
     <div class="col-md-6 stretch-card grid-margin">
       <div class="card bg-gradient-danger card-img-holder text-white">
         <div class="card-body">
-          <img src="{% static 'assets/images/dashboard/circle.svg' %}" class="card-img-absolute" alt="circle-image" onclick="post_servico_saudavel()" style="cursor: pointer" />
-          <h3 class="font-weight-normal mb-3" style="text-align: center">Aplicação Saudável <i class="mdi mdi-chart-line mdi-24px float-right"></i>
+          <!--<img src="{% static 'assets/images/dashboard/circle.svg' %}" class="card-img-absolute" alt="circle-image"/>-->
+          <h3 class="font-weight-normal mb-3" style="text-align: center">Aplicação Saudável <i class="mdi mdi-chart-line mdi-24px float-right" onclick="post_servico_saudavel()" style=" cursor: pointer"></i>
           </h3>
           <span></span>
+          <h6 class="card-text">Numero de requisicoes realizadas</h6>
+          <h2 class="mb-5" id="numero_requisicoes_realizadas_saudavel">{{num_total_requicoes_saudavel}}</h2>
+          <h6 class="card-text">Numero de requisicoes bem sucedidas</h6>
+          <h2 class="mb-5" id="numero_requisicoes_bem_sucedidas_saudavel">{{num_requisicoes_com_sucesso_saudavel}}</h2>
           <h6 class="card-text">Tempo médio de requisição</h6>
           <h2 class="mb-5" id="tempo_medio_resposta_saudavel">{{tempo_request_saudavel}}</h2>
           <h6 class="card-text">Última requisição</h6>
@@ -26,10 +30,14 @@
     <div class="col-md-6 stretch-card grid-margin">
       <div class="card bg-gradient-danger card-img-holder text-white">
         <div class="card-body">
-          <img src="{% static 'assets/images/dashboard/circle.svg' %}" class="card-img-absolute" alt="circle-image" onclick="post_servico_teste()" style="cursor: pointer"/>
-          <h3 class="font-weight-normal mb-3" style="text-align: center">Aplicação Controlada <i class="mdi mdi-chart-line mdi-24px float-right"></i>
+          <!--<img src="{% static 'assets/images/dashboard/circle.svg' %}" class="card-img-absolute" alt="circle-image" />-->
+          <h3 class="font-weight-normal mb-3" style="text-align: center">Aplicação Controlada <i class="mdi mdi-chart-line mdi-24px float-right" onclick="post_servico_teste()" style="cursor: pointer"></i>
           </h3>
           <span></span>
+          <h6 class="card-text">Numero de requisicoes realizadas</h6>
+          <h2 class="mb-5" id="numero_requisicoes_realizadas_chaos">{{num_total_requicoes_chaos}}</h2>
+          <h6 class="card-text">Numero de requisicoes bem sucedidas</h6>
+          <h2 class="mb-5" id="numero_requisicoes_bem_sucedidas_chaos">{{num_requisicoes_com_sucesso_chaos}}</h2>
           <h6 class="card-text">Tempo médio de requisição</h6>
           <h2 class="mb-5" id="tempo_medio_resposta_chaos">{{tempo_request_chaos}}</h2>
           <h6 class="card-text">Última requisição</h6>

--- a/interface/webserver/webserver/urls.py
+++ b/interface/webserver/webserver/urls.py
@@ -19,10 +19,11 @@ from webserver import views
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('servico1/', views.servico_saudavel, name='servico_saudavel'),
+    path('servico1/', views.render_status_servico, name='render_status_servico'),
     
     path('', views.home, name='home_page'),
-    
+    path('request_saudavel/',views.servico_saudavel, name='servico_saudavel'),
+    path('request_teste/',views.servico_teste, name='servico_teste'),
     
     
 ]

--- a/interface/webserver/webserver/views.py
+++ b/interface/webserver/webserver/views.py
@@ -43,7 +43,7 @@ def home(request):
 def requsicao_servico_teste(servico):
     parametros = { 'servico': servico }
     ip = get_ip("SIMULADOR_REQUESTS")
-    return realiza_request(host=ip)
+    return realiza_request(host=ip, parametros)
 
 def gera_contexto(sufixo: str):
     context = {}

--- a/interface/webserver/webserver/views.py
+++ b/interface/webserver/webserver/views.py
@@ -1,13 +1,38 @@
+import json
 import os
+from datetime import datetime, timedelta
 
+import redis
+import requests
 from django.http import JsonResponse
 from django.shortcuts import render
-
-from datetime import datetime, timedelta
+from webserver.connect_db_twitter import (conecta_com_mysql,
+                                          obtem_lista_twitches)
 from webserver.settings import BD_INFO
 
-from webserver.connect_db_twitter import conecta_com_mysql, obtem_lista_twitches
 
+def get_ip(servico:str) -> str:
+    
+    # kubectl get services/consumidor-twitches-svc -o go-template='{{index .spec.ClusterIP}}'
+    # Conecta no Banco
+    r = redis.Redis(host='10.103.199.135')
+    ip = r.get(servico).decode('utf8')
+    
+    # Cancela Conexao com DB
+    del r
+    
+    # obtem IP do servico desejado
+    return str(ip)
+
+def realiza_request(host: str, pagina:str = "", parametros: dict = {}):
+    
+    prefixo_url = 'http://'
+    
+    # Realiza Request
+    response = requests.get(prefixo_url + host + pagina, params=parametros)
+    
+    return response
+    
 
 def home(request):
     context = {
@@ -15,16 +40,52 @@ def home(request):
     }
     return render(request, 'webserver/home.html', context)
 
-def servico_saudavel(request):    
+def requsicao_servico_teste(servico):
+    parametros = { 'servico': servico }
+    ip = get_ip("SIMULADOR_REQUESTS")
+    return realiza_request(host=ip)
+
+def servico_saudavel(request):
+    """
+        Realiza request em servico saudavel
+    """
+    context = {}
+    try:
+        response = requsicao_servico_teste(servico="teste")
+        context['tempo_request_saudavel'] = json.loads(response.content)['Tempo_medio_por_request']
+    except Exception:
+        context['tempo_request_saudavel'] = "---"
+    
+    context['ultima_requisicao_saudavel']= datetime.now().strftime('%H:%M:%S %d/%m/%Y')
+    return JsonResponse(context)
+
+def servico_teste(request):
+    """
+        Realiza request em servico de teste
+    """
+    
+    context = {}
+    try:
+        response = requsicao_servico_teste(servico="teste")
+        context['tempo_request_chaos'] = json.loads(response.content)['Tempo_medio_por_request']
+    except Exception:
+        context['tempo_request_chaos'] = "---"
+    
+    context['ultima_requisicao_chaos']= datetime.now().strftime('%H:%M:%S %d/%m/%Y')
+    return JsonResponse(context)
+
+
+def render_status_servico(request):
+    
     context= {
-        'tempo_request_saudavel': "20ms",
-        'tempo_request_chaos': "40ms",
+        'tempo_request_saudavel': "---ms",
+        'tempo_request_chaos': "---ms",
         'ultima_requisicao_saudavel': datetime.now().strftime('%H:%M:%S %d/%m/%Y'),
-        'ultima_requisicao_chaos': (datetime.now() + timedelta(seconds=1234)).strftime('%H:%M:%S %d/%m/%Y')
+        'ultima_requisicao_chaos': datetime.now().strftime('%H:%M:%S %d/%m/%Y')
     }
-    if request.method == "GET":
-        return render(request,'webserver/servico1.html', context)
-    elif request.method =="POST":
-        return JsonResponse(context)
-    else:
-        return JsonResponse({})
+    
+    return render(request,'webserver/servico1.html', context)
+
+
+# COmando para obter nome dos pods 
+# kubectl get pods -o wide | grep -E -o "(consumidor-twitches-deployment-)[a-z0-9]{10}-[a-z0-9]{5}"

--- a/interface/webserver/webserver/views.py
+++ b/interface/webserver/webserver/views.py
@@ -54,7 +54,7 @@ def gera_contexto(sufixo: str):
         context['numero_requisicoes_realizadas_' + sufixo]= dict_response['Numero_Requisicoes']
         
         if "200" in dict_response['Ocorrencia_status_code'].keys():
-            context['numero_requisicoes_bem_sucedidas_' + sufixo]= dict_response['Ocorrencia_status_code']
+            context['numero_requisicoes_bem_sucedidas_' + sufixo]= dict_response['Ocorrencia_status_code']["200"]
         else:
             context['numero_requisicoes_bem_sucedidas_' + sufixo]=0
             

--- a/interface/webserver/webserver/views.py
+++ b/interface/webserver/webserver/views.py
@@ -45,18 +45,36 @@ def requsicao_servico_teste(servico):
     ip = get_ip("SIMULADOR_REQUESTS")
     return realiza_request(host=ip)
 
+def gera_contexto(sufixo: str):
+    context = {}
+    try:
+        raise ValueError
+        response = requsicao_servico_teste(servico="teste")
+        dict_response = json.loads(response.content)
+        context['tempo_medio_resposta_' + sufixo] = "{0:.2}ms".format(dict_response['Tempo_medio_por_request']*1000)
+        context['numero_requisicoes_realizadas_' + sufixo]= dict_response['Numero_Requisicoes']
+        
+        if "200" in dict_response['Ocorrencia_status_code'].keys():
+            context['numero_requisicoes_bem_sucedidas_' + sufixo]= dict_response['Ocorrencia_status_code']
+        else:
+            context['numero_requisicoes_bem_sucedidas_' + sufixo]=0
+            
+    except Exception:
+        context['tempo_medio_resposta_' + sufixo] = "---"
+        context['numero_requisicoes_realizadas_' + sufixo]= 0
+        context['numero_requisicoes_bem_sucedidas_' + sufixo]= 0
+        
+    
+    context['ultima_requisicao_' + sufixo]= datetime.now().strftime('%H:%M:%S %d/%m/%Y')
+    
+    return context
+    
+
 def servico_saudavel(request):
     """
         Realiza request em servico saudavel
     """
-    context = {}
-    try:
-        response = requsicao_servico_teste(servico="teste")
-        context['tempo_request_saudavel'] = json.loads(response.content)['Tempo_medio_por_request']
-    except Exception:
-        context['tempo_request_saudavel'] = "---"
-    
-    context['ultima_requisicao_saudavel']= datetime.now().strftime('%H:%M:%S %d/%m/%Y')
+    context = gera_contexto("saudavel")
     return JsonResponse(context)
 
 def servico_teste(request):
@@ -64,22 +82,15 @@ def servico_teste(request):
         Realiza request em servico de teste
     """
     
-    context = {}
-    try:
-        response = requsicao_servico_teste(servico="teste")
-        context['tempo_request_chaos'] = json.loads(response.content)['Tempo_medio_por_request']
-    except Exception:
-        context['tempo_request_chaos'] = "---"
-    
-    context['ultima_requisicao_chaos']= datetime.now().strftime('%H:%M:%S %d/%m/%Y')
+    context = context = gera_contexto("chaos")
     return JsonResponse(context)
 
 
 def render_status_servico(request):
     
     context= {
-        'tempo_request_saudavel': "---ms",
-        'tempo_request_chaos': "---ms",
+        'tempo_medio_resposta_saudavel': "---ms",
+        'tempo_medio_resposta_chaos': "---ms",
         'ultima_requisicao_saudavel': datetime.now().strftime('%H:%M:%S %d/%m/%Y'),
         'ultima_requisicao_chaos': datetime.now().strftime('%H:%M:%S %d/%m/%Y')
     }

--- a/interface/webserver/webserver/views.py
+++ b/interface/webserver/webserver/views.py
@@ -48,7 +48,6 @@ def requsicao_servico_teste(servico):
 def gera_contexto(sufixo: str):
     context = {}
     try:
-        raise ValueError
         response = requsicao_servico_teste(servico="teste")
         dict_response = json.loads(response.content)
         context['tempo_medio_resposta_' + sufixo] = "{0:.2}ms".format(dict_response['Tempo_medio_por_request']*1000)

--- a/interface/webserver/webserver/views.py
+++ b/interface/webserver/webserver/views.py
@@ -43,7 +43,7 @@ def home(request):
 def requsicao_servico_teste(servico):
     parametros = { 'servico': servico }
     ip = get_ip("SIMULADOR_REQUESTS")
-    return realiza_request(host=ip, parametros)
+    return realiza_request(host=ip, parametros=parametros)
 
 def gera_contexto(sufixo: str):
     context = {}

--- a/kubernetes-conf/bot-deployment.yaml
+++ b/kubernetes-conf/bot-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bot-simulador-requests-deployment
+  labels: 
+    app: bot-simulador-requests
+spec:
+  replicas: 1
+  selector:
+      matchLabels:
+        app: bot-simulador-requests
+  template:
+    metadata:
+      labels:
+        app: bot-simulador-requests
+    spec:
+      containers:
+      - name: bot-simulador-requests
+        image: pupio/tcc:bot-simulador-requests
+        ports:
+        - containerPort: 80

--- a/kubernetes-conf/bot-deployment.yaml
+++ b/kubernetes-conf/bot-deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: bot-simulador-requests
-        image: pupio/tcc:bot-simulador-requests
+        image: pupio/tcc:bot-simulador-requests-v2
         ports:
         - containerPort: 80

--- a/kubernetes-conf/bot-service.yaml
+++ b/kubernetes-conf/bot-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bot-simulador-requests-svc
+  labels:
+    app: bot-simulador-requests
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+  selector:
+    app: bot-simulador-requests

--- a/kubernetes-conf/deployment.yaml
+++ b/kubernetes-conf/deployment.yaml
@@ -19,30 +19,6 @@ spec:
         image: pupio/tcc:consumidor-twitches
         ports:
         - containerPort: 80
-
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: bot-simulador-requests-deployment
-  labels: 
-    app: bot-simulador-requests
-spec:
-  replicas: 1
-  selector:
-      matchLabels:
-        app: bot-simulador-requests
-  template:
-    metadata:
-      labels:
-        app: bot-simulador-requests
-    spec:
-      containers:
-      - name: bot-simulador-requests
-        image: pupio/tcc:bot-simulador-requests
-        ports:
-        - containerPort: 80
-
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/kubernetes-conf/deployment.yaml
+++ b/kubernetes-conf/deployment.yaml
@@ -23,6 +23,28 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: chaos-consumidor-twitches-deployment
+  labels: 
+    app: chaos-consumidor-twitches
+spec:
+  replicas: 10
+  selector:
+      matchLabels:
+        app: chaos-consumidor-twitches
+  template:
+    metadata:
+      labels:
+        app: chaos-consumidor-twitches
+    spec:
+      containers:
+      - name: chaos-consumidor-twitches
+        image: pupio/tcc:consumidor-twitches
+        ports:
+        - containerPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
   name: twitter-api-kafka-deployment
   labels: 
     app: twitter-api-kafka

--- a/kubernetes-conf/service.yaml
+++ b/kubernetes-conf/service.yaml
@@ -10,6 +10,19 @@ spec:
   - port: 80
   selector:
     app: consumidor-twitches
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: chaos-consumidor-twitches-svc
+  labels:
+    app: chaos-consumidor-twitches
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+  selector:
+    app: chaos-consumidor-twitches
   
 ---
 apiVersion: v1

--- a/kubernetes-conf/service.yaml
+++ b/kubernetes-conf/service.yaml
@@ -15,19 +15,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: bot-simulador-requests-svc
-  labels:
-    app: bot-simulador-requests
-spec:
-  type: NodePort
-  ports:
-  - port: 80
-  selector:
-    app: bot-simulador-requests
----
-apiVersion: v1
-kind: Service
-metadata:
   name: twitter-api-kafka-svc
   labels:
     app: twitter-api-kafka


### PR DESCRIPTION
# Objetivos
- Adaptar servicos para poder exibir no front informacoes reais dos servico saudavel e do caotico

# Principais alteracoes

### consumidor_twitches
- adicionado libs do toolkit nos pods consumidores de twittes

### interface
- Utiliz Redis para saber o IP do simulador de requests
- Alterei front para ter um fundo roxo
- Adicionei funcao para fazer requisicao no ambiente saudavel e outra no caotico
- ADicionei campos de informacoes no front
- Interface utiliza dados reais para exibir no front

### kubernetes-conf
- Separacao do deployment do bot-simulador-requests
- Separacao do servico do bot-simulador-requests
- Adicao do consumidor de twitches caotico

### simulador_requests
- Atualizacao no ip do Redis
- Adicionado variaveis para obter IP tanto do servico saudavel, quanto do caotico

